### PR TITLE
Display all local and remote video

### DIFF
--- a/frontend/css/client.css
+++ b/frontend/css/client.css
@@ -16,8 +16,8 @@
     --border: 0.1px solid #45494c;
     --border-radius: 1rem;
     --video-obj-fit: cover;
-    --my-video-wrap-width: 320px;
-    --my-video-wrap-height: 240px;
+    --my-video-wrap-width: auto;
+    --my-video-wrap-height: 210px;
     --settings-width: 280px;
     --chat-width: 320px;
     --btn-hover-scale: scale(1.1);

--- a/frontend/html/client.html
+++ b/frontend/html/client.html
@@ -112,6 +112,10 @@ Wait user to join.
                     <td><span>✨ Best quality</span></td>
                     <td><input id="switchMaxVideoQuality" class="toggle" type="checkbox" /></td>
                 </tr>
+                <tr id="aspectRatioDiv">
+                    <td><span>📌 Aspect ratio</span></td>
+                    <td><input id="switchKeepAspectRatio" class="toggle" type="checkbox" /></td>
+                </tr>
                 <tr id="pushToTalkDiv">
                     <td><span>👆 Push to talk</span></td>
                     <td><input id="switchPushToTalk" class="toggle" type="checkbox" /></td>

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -42,6 +42,7 @@ const videoFpsSelect = document.getElementById('videoFpsSelect');
 const maxVideoQualityDiv = document.getElementById('maxVideoQualityDiv');
 const pushToTalkDiv = document.getElementById('pushToTalkDiv');
 const switchMaxVideoQuality = document.getElementById('switchMaxVideoQuality');
+const switchKeepAspectRatio = document.getElementById('switchKeepAspectRatio');
 const switchPushToTalk = document.getElementById('switchPushToTalk');
 const sessionTime = document.getElementById('sessionTime');
 const chat = document.getElementById('chat');
@@ -55,6 +56,7 @@ const roomURL = window.location.origin + '/?room=' + roomId;
 
 const config = {
     forceToMaxVideoAndFps: window.localStorage.forceToMaxVideoAndFps == 'true' || false,
+    keepAspectRatio: window.localStorage.keepAspectRatio == 'true' || false,
 };
 
 const image = {
@@ -587,7 +589,7 @@ function setLocalMedia(stream) {
     myLocalMedia.muted = true;
     myLocalMedia.volume = 0;
     myLocalMedia.controls = false;
-    myLocalMedia.style.objectFit = "contain";
+    myLocalMedia.style.objectFit = config.keepAspectRatio ? 'contain' : 'cover';
     myVideoWrap.id = 'myVideoWrap';
     myVideoWrap.className = 'myVideoWrap';
     myVideoWrap.appendChild(myVideoHeader);
@@ -640,7 +642,7 @@ function setRemoteMedia(stream, peers, peerId) {
     remoteMedia.playsInline = true;
     remoteMedia.autoplay = true;
     remoteMedia.controls = false;
-    remoteMedia.style.objectFit = "contain";
+    remoteMedia.style.objectFit = config.keepAspectRatio ? 'contain' : 'cover';
     peerMediaElements[peerId] = remoteMedia;
     remoteVideoWrap.id = peerId + '_remoteVideoWrap';
     remoteVideoWrap.className = 'remoteVideoWrap';
@@ -655,6 +657,10 @@ function setRemoteMedia(stream, peers, peerId) {
     handleVideoZoom(remoteMedia, remoteVideoAvatarImage);
     setPeerVideoStatus(peerId, peerVideo);
     setPeerAudioStatus(peerId, peerAudio);
+    if (isMobileDevice && !isTabletDevice && !isIPadDevice) {
+        document.documentElement.style.setProperty('--my-video-wrap-width', '190px');
+        document.documentElement.style.setProperty('--my-video-wrap-height', '150px');
+    }
     if (peerVideo && peerScreen) setPeerScreenStatus(peerId, peerScreen);
 }
 
@@ -756,6 +762,13 @@ function handleEvents() {
                 6000,
             );
         }
+        playSound('switch');
+    };
+    switchKeepAspectRatio.checked = config.keepAspectRatio;
+    switchKeepAspectRatio.onchange = (e) => {
+        config.keepAspectRatio = e.currentTarget.checked;
+        window.localStorage.keepAspectRatio = config.keepAspectRatio;
+        changeAspectRatio(config.keepAspectRatio);
         playSound('switch');
     };
     if (isMobileDevice) {
@@ -896,7 +909,7 @@ async function toggleScreenSharing() {
             setVideoStatus(isScreenStreaming);
             setScreenStatus(isScreenStreaming);
             myVideo.classList.toggle('mirror');
-            myVideo.style.objectFit = isScreenStreaming ? 'contain' : 'cover';
+            myVideo.style.objectFit = isScreenStreaming || config.keepAspectRatio ? 'contain' : 'cover';
             initScreenShareBtn.className = isScreenStreaming ? className.screenOff : className.screenOn;
             screenShareBtn.className = isScreenStreaming ? className.screenOff : className.screenOn;
             if (!isScreenStreaming && isMyVideoActiveBefore) videoBtn.click();

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -587,6 +587,7 @@ function setLocalMedia(stream) {
     myLocalMedia.muted = true;
     myLocalMedia.volume = 0;
     myLocalMedia.controls = false;
+    myLocalMedia.style.objectFit = "contain";
     myVideoWrap.id = 'myVideoWrap';
     myVideoWrap.className = 'myVideoWrap';
     myVideoWrap.appendChild(myVideoHeader);
@@ -639,6 +640,7 @@ function setRemoteMedia(stream, peers, peerId) {
     remoteMedia.playsInline = true;
     remoteMedia.autoplay = true;
     remoteMedia.controls = false;
+    remoteMedia.style.objectFit = "contain";
     peerMediaElements[peerId] = remoteMedia;
     remoteVideoWrap.id = peerId + '_remoteVideoWrap';
     remoteVideoWrap.className = 'remoteVideoWrap';
@@ -654,10 +656,6 @@ function setRemoteMedia(stream, peers, peerId) {
     setPeerVideoStatus(peerId, peerVideo);
     setPeerAudioStatus(peerId, peerAudio);
     if (peerVideo && peerScreen) setPeerScreenStatus(peerId, peerScreen);
-    if (isMobileDevice && !isTabletDevice && !isIPadDevice) {
-        document.documentElement.style.setProperty('--my-video-wrap-width', '190px');
-        document.documentElement.style.setProperty('--my-video-wrap-height', '150px');
-    }
 }
 
 function handleIncomingDataChannelMessage(config) {

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -658,8 +658,8 @@ function setRemoteMedia(stream, peers, peerId) {
     setPeerVideoStatus(peerId, peerVideo);
     setPeerAudioStatus(peerId, peerAudio);
     if (isMobileDevice && !isTabletDevice && !isIPadDevice) {
-        document.documentElement.style.setProperty('--my-video-wrap-width', '190px');
-        document.documentElement.style.setProperty('--my-video-wrap-height', '150px');
+        document.documentElement.style.setProperty('--my-video-wrap-width', '130px');
+        document.documentElement.style.setProperty('--my-video-wrap-height', 'auto');
     }
     if (peerVideo && peerScreen) setPeerScreenStatus(peerId, peerScreen);
 }

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -35,7 +35,7 @@ function isDesktop() {
 
 function changeAspectRatio(aspectRatio) {
     const videoElements = document.querySelectorAll('video');
-    videoElements.forEach(video => {
+    videoElements.forEach((video) => {
         video.style.objectFit = aspectRatio ? 'contain' : 'cover';
     });
 }

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -33,6 +33,13 @@ function isDesktop() {
     return !isMobileDevice && !isTabletDevice && !isIPadDevice;
 }
 
+function changeAspectRatio(aspectRatio) {
+    const videoElements = document.querySelectorAll('video');
+    videoElements.forEach(video => {
+        video.style.objectFit = aspectRatio ? 'contain' : 'cover';
+    });
+}
+
 function isFullScreen() {
     const elementFullScreen =
         document.fullscreenElement ||


### PR DESCRIPTION
Reason for PR: When I am testing c2c with my laptop and my phone, both my Phone and my PC show a pixelated face from me. And the face takes up the whole screen. However, in PiP mode (all video displayed and original aspect ratio), the video isn't too bad.
(btw I am also working on a PR on codec and bitrate to improve video quality)

In this PR:
The wrapper of myLocalVideo will automatically fit the aspect ratio of local video.
RemoteVideo will fit the screen in the original aspect ratio. (grey background will be shown if they don't match perfectly.)
"my-video-wrap-width" and "my-video-wrap-height" are tested on my laptop and phone. These two numbers seems to work good enough for me. But I am open to any changes.