### PR TITLE
Add video codec and max bitrate settings

### DIFF
--- a/frontend/css/client.css
+++ b/frontend/css/client.css
@@ -16,8 +16,8 @@
     --border: 0.1px solid #45494c;
     --border-radius: 1rem;
     --video-obj-fit: cover;
-    --my-video-wrap-width: 320px;
-    --my-video-wrap-height: 240px;
+    --my-video-wrap-width: auto;
+    --my-video-wrap-height: 210px;
     --settings-width: 280px;
     --chat-width: 320px;
     --btn-hover-scale: scale(1.1);

--- a/frontend/html/client.html
+++ b/frontend/html/client.html
@@ -107,6 +107,22 @@ Wait user to join.
             <label for="audioSource">🎙️ Microphone</label>
             <select id="audioSource"></select>
             <hr />
+            <label>Video codec</label>
+            <select id="videoSenderCodecSelect">
+                <option value="default">Default</option>
+                <option value="AV1/VP9">AV1/VP9</option>
+                <option value="VP9/VP8">VP9/VP8</option>
+            </select>
+            <label>Video max bitrate (Mbps)</label>
+            <select id="videoSenderMaxBitrateSelect">
+                <option value="default">Default</option>
+                <option value="16">16</option>
+                <option value="8">8</option>
+                <option value="4">4</option>
+                <option value="2">2</option>
+                <option value="1">1</option>
+            </select>
+            <hr />
             <table id="settingsTable">
                 <tr id="maxVideoQualityDiv">
                     <td><span>✨ Best quality</span></td>

--- a/frontend/html/client.html
+++ b/frontend/html/client.html
@@ -128,6 +128,10 @@ Wait user to join.
                     <td><span>✨ Best quality</span></td>
                     <td><input id="switchMaxVideoQuality" class="toggle" type="checkbox" /></td>
                 </tr>
+                <tr id="aspectRatioDiv">
+                    <td><span>📌 Aspect ratio</span></td>
+                    <td><input id="switchKeepAspectRatio" class="toggle" type="checkbox" /></td>
+                </tr>
                 <tr id="pushToTalkDiv">
                     <td><span>👆 Push to talk</span></td>
                     <td><input id="switchPushToTalk" class="toggle" type="checkbox" /></td>

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -614,6 +614,7 @@ function setLocalMedia(stream) {
     myLocalMedia.muted = true;
     myLocalMedia.volume = 0;
     myLocalMedia.controls = false;
+    myLocalMedia.style.objectFit = "contain";
     myVideoWrap.id = 'myVideoWrap';
     myVideoWrap.className = 'myVideoWrap';
     myVideoWrap.appendChild(myVideoHeader);
@@ -666,6 +667,7 @@ function setRemoteMedia(stream, peers, peerId) {
     remoteMedia.playsInline = true;
     remoteMedia.autoplay = true;
     remoteMedia.controls = false;
+    remoteMedia.style.objectFit = "contain";
     peerMediaElements[peerId] = remoteMedia;
     remoteVideoWrap.id = peerId + '_remoteVideoWrap';
     remoteVideoWrap.className = 'remoteVideoWrap';
@@ -681,10 +683,6 @@ function setRemoteMedia(stream, peers, peerId) {
     setPeerVideoStatus(peerId, peerVideo);
     setPeerAudioStatus(peerId, peerAudio);
     if (peerVideo && peerScreen) setPeerScreenStatus(peerId, peerScreen);
-    if (isMobileDevice && !isTabletDevice && !isIPadDevice) {
-        document.documentElement.style.setProperty('--my-video-wrap-width', '190px');
-        document.documentElement.style.setProperty('--my-video-wrap-height', '150px');
-    }
 }
 
 function handleIncomingDataChannelMessage(config) {

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -43,6 +43,8 @@ const maxVideoQualityDiv = document.getElementById('maxVideoQualityDiv');
 const pushToTalkDiv = document.getElementById('pushToTalkDiv');
 const switchMaxVideoQuality = document.getElementById('switchMaxVideoQuality');
 const switchPushToTalk = document.getElementById('switchPushToTalk');
+const videoSenderCodecSelect = document.getElementById('videoSenderCodecSelect');
+const videoSenderMaxBitrateSelect = document.getElementById('videoSenderMaxBitrateSelect');
 const sessionTime = document.getElementById('sessionTime');
 const chat = document.getElementById('chat');
 const chatOpenBtn = document.getElementById('chatOpenBtn');
@@ -55,6 +57,8 @@ const roomURL = window.location.origin + '/?room=' + roomId;
 
 const config = {
     forceToMaxVideoAndFps: window.localStorage.forceToMaxVideoAndFps == 'true' || false,
+    videoSenderCodec: window.localStorage.videoSenderCodec || "default",
+    videoSenderMaxBitrate: window.localStorage.videoSenderMaxBitrate || "default",
 };
 
 const image = {
@@ -264,6 +268,27 @@ function handleServerInfo(config) {
     redirectURL = config.redirectURL;
 }
 
+function handleCodec(peerConnection) {
+    let videoTransceiver = peerConnection.getTransceivers().find((s) => (s.sender.track ? s.sender.track.kind === 'video' : false));
+    if (videoTransceiver) {
+        if (config.videoSenderCodec != "default") {
+            let supportedCodec = RTCRtpSender.getCapabilities("video").codecs;
+            let selectedCodec = config.videoSenderCodec.split("/").map((name) =>
+                supportedCodec.filter((codec) => codec.mimeType.includes(name))
+            ).flat();
+            videoTransceiver.setCodecPreferences(selectedCodec);
+            console.log("Codecs:", selectedCodec);
+        }
+
+        if (config.videoSenderMaxBitrate != "default") {
+            let videoSender = videoTransceiver.sender;
+            let videoParam = videoSender.getParameters();
+            videoParam.encodings[0].maxBitrate = config.videoSenderMaxBitrate * 1000 * 1000;
+            videoSender.setParameters(videoParam);
+        }
+    }
+}
+
 function handleAddPeer(config) {
     if (roomPeersCount > 2) {
         return roomIsBusy();
@@ -375,6 +400,7 @@ function handleAddTracks(peerId) {
 function handleRtcOffer(peerId) {
     peerConnections[peerId].onnegotiationneeded = () => {
         console.log('Creating RTC offer to', peerId);
+        handleCodec(peerConnections[peerId]);
         peerConnections[peerId]
             .createOffer()
             .then((localDescription) => {
@@ -408,6 +434,7 @@ function handleSessionDescription(config) {
             console.log('Set remote description done!');
             if (sessionDescription.type == 'offer') {
                 console.log('Creating answer');
+                handleCodec(peerConnections[peerId]);
                 peerConnections[peerId]
                     .createAnswer()
                     .then((localDescription) => {
@@ -758,6 +785,32 @@ function handleEvents() {
                 6000,
             );
         }
+        playSound('switch');
+    };
+    videoSenderCodecSelect.value = config.videoSenderCodec;
+    videoSenderCodecSelect.onchange = (e) => {
+        config.videoSenderCodec = e.target.value;
+        window.localStorage.videoSenderCodec = e.target.value;
+        popupMessage(
+            'toast',
+            'Video codec changed to ' + e.target.value,
+            'Please refresh for the setting to take effect',
+            'top',
+            6000,
+        );
+        playSound('switch');
+    };
+    videoSenderMaxBitrateSelect.value = config.videoSenderMaxBitrate;
+    videoSenderMaxBitrateSelect.onchange = (e) => {
+        config.videoSenderMaxBitrate = e.target.value;
+        window.localStorage.videoSenderMaxBitrate = e.target.value;
+        popupMessage(
+            'toast',
+            'Video max bitrate changed to ' + e.target.value,
+            'Please refresh for the setting to take effect',
+            'top',
+            6000,
+        );
         playSound('switch');
     };
     if (isMobileDevice) {

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -42,6 +42,7 @@ const videoFpsSelect = document.getElementById('videoFpsSelect');
 const maxVideoQualityDiv = document.getElementById('maxVideoQualityDiv');
 const pushToTalkDiv = document.getElementById('pushToTalkDiv');
 const switchMaxVideoQuality = document.getElementById('switchMaxVideoQuality');
+const switchKeepAspectRatio = document.getElementById('switchKeepAspectRatio');
 const switchPushToTalk = document.getElementById('switchPushToTalk');
 const videoSenderCodecSelect = document.getElementById('videoSenderCodecSelect');
 const videoSenderMaxBitrateSelect = document.getElementById('videoSenderMaxBitrateSelect');
@@ -59,6 +60,7 @@ const config = {
     forceToMaxVideoAndFps: window.localStorage.forceToMaxVideoAndFps == 'true' || false,
     videoSenderCodec: window.localStorage.videoSenderCodec || "default",
     videoSenderMaxBitrate: window.localStorage.videoSenderMaxBitrate || "default",
+    keepAspectRatio: window.localStorage.keepAspectRatio == 'true' || false,
 };
 
 const image = {
@@ -614,7 +616,7 @@ function setLocalMedia(stream) {
     myLocalMedia.muted = true;
     myLocalMedia.volume = 0;
     myLocalMedia.controls = false;
-    myLocalMedia.style.objectFit = "contain";
+    myLocalMedia.style.objectFit = config.keepAspectRatio ? 'contain' : 'cover';
     myVideoWrap.id = 'myVideoWrap';
     myVideoWrap.className = 'myVideoWrap';
     myVideoWrap.appendChild(myVideoHeader);
@@ -667,7 +669,7 @@ function setRemoteMedia(stream, peers, peerId) {
     remoteMedia.playsInline = true;
     remoteMedia.autoplay = true;
     remoteMedia.controls = false;
-    remoteMedia.style.objectFit = "contain";
+    remoteMedia.style.objectFit = config.keepAspectRatio ? 'contain' : 'cover';
     peerMediaElements[peerId] = remoteMedia;
     remoteVideoWrap.id = peerId + '_remoteVideoWrap';
     remoteVideoWrap.className = 'remoteVideoWrap';
@@ -682,6 +684,10 @@ function setRemoteMedia(stream, peers, peerId) {
     handleVideoZoom(remoteMedia, remoteVideoAvatarImage);
     setPeerVideoStatus(peerId, peerVideo);
     setPeerAudioStatus(peerId, peerAudio);
+    if (isMobileDevice && !isTabletDevice && !isIPadDevice) {
+        document.documentElement.style.setProperty('--my-video-wrap-width', '190px');
+        document.documentElement.style.setProperty('--my-video-wrap-height', '150px');
+    }
     if (peerVideo && peerScreen) setPeerScreenStatus(peerId, peerScreen);
 }
 
@@ -809,6 +815,13 @@ function handleEvents() {
             'top',
             6000,
         );
+        playSound('switch');
+    };
+    switchKeepAspectRatio.checked = config.keepAspectRatio;
+    switchKeepAspectRatio.onchange = (e) => {
+        config.keepAspectRatio = e.currentTarget.checked;
+        window.localStorage.keepAspectRatio = config.keepAspectRatio;
+        changeAspectRatio(config.keepAspectRatio);
         playSound('switch');
     };
     if (isMobileDevice) {
@@ -949,7 +962,7 @@ async function toggleScreenSharing() {
             setVideoStatus(isScreenStreaming);
             setScreenStatus(isScreenStreaming);
             myVideo.classList.toggle('mirror');
-            myVideo.style.objectFit = isScreenStreaming ? 'contain' : 'cover';
+            myVideo.style.objectFit = isScreenStreaming || config.keepAspectRatio ? 'contain' : 'cover';
             initScreenShareBtn.className = isScreenStreaming ? className.screenOff : className.screenOn;
             screenShareBtn.className = isScreenStreaming ? className.screenOff : className.screenOn;
             if (!isScreenStreaming && isMyVideoActiveBefore) videoBtn.click();

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -61,6 +61,8 @@ const config = {
     videoSenderCodec: window.localStorage.videoSenderCodec || "default",
     videoSenderMaxBitrate: window.localStorage.videoSenderMaxBitrate || "default",
     keepAspectRatio: window.localStorage.keepAspectRatio == 'true' || false,
+    videoSenderCodec: window.localStorage.videoSenderCodec || "default",
+    videoSenderMaxBitrate: window.localStorage.videoSenderMaxBitrate || "default",
 };
 
 const image = {
@@ -822,6 +824,32 @@ function handleEvents() {
         config.keepAspectRatio = e.currentTarget.checked;
         window.localStorage.keepAspectRatio = config.keepAspectRatio;
         changeAspectRatio(config.keepAspectRatio);
+        playSound('switch');
+    };
+    videoSenderCodecSelect.value = config.videoSenderCodec;
+    videoSenderCodecSelect.onchange = (e) => {
+        config.videoSenderCodec = e.target.value;
+        window.localStorage.videoSenderCodec = e.target.value;
+        popupMessage(
+            'toast',
+            'Video codec changed to ' + e.target.value,
+            'Please refresh for the setting to take effect',
+            'top',
+            6000,
+        );
+        playSound('switch');
+    };
+    videoSenderMaxBitrateSelect.value = config.videoSenderMaxBitrate;
+    videoSenderMaxBitrateSelect.onchange = (e) => {
+        config.videoSenderMaxBitrate = e.target.value;
+        window.localStorage.videoSenderMaxBitrate = e.target.value;
+        popupMessage(
+            'toast',
+            'Video max bitrate changed to ' + e.target.value,
+            'Please refresh for the setting to take effect',
+            'top',
+            6000,
+        );
         playSound('switch');
     };
     if (isMobileDevice) {

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -685,8 +685,8 @@ function setRemoteMedia(stream, peers, peerId) {
     setPeerVideoStatus(peerId, peerVideo);
     setPeerAudioStatus(peerId, peerAudio);
     if (isMobileDevice && !isTabletDevice && !isIPadDevice) {
-        document.documentElement.style.setProperty('--my-video-wrap-width', '190px');
-        document.documentElement.style.setProperty('--my-video-wrap-height', '150px');
+        document.documentElement.style.setProperty('--my-video-wrap-width', '130px');
+        document.documentElement.style.setProperty('--my-video-wrap-height', 'auto');
     }
     if (peerVideo && peerScreen) setPeerScreenStatus(peerId, peerScreen);
 }

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -35,7 +35,7 @@ function isDesktop() {
 
 function changeAspectRatio(aspectRatio) {
     const videoElements = document.querySelectorAll('video');
-    videoElements.forEach(video => {
+    videoElements.forEach((video) => {
         video.style.objectFit = aspectRatio ? 'contain' : 'cover';
     });
 }

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -33,6 +33,13 @@ function isDesktop() {
     return !isMobileDevice && !isTabletDevice && !isIPadDevice;
 }
 
+function changeAspectRatio(aspectRatio) {
+    const videoElements = document.querySelectorAll('video');
+    videoElements.forEach(video => {
+        video.style.objectFit = aspectRatio ? 'contain' : 'cover';
+    });
+}
+
 function isFullScreen() {
     const elementFullScreen =
         document.fullscreenElement ||


### PR DESCRIPTION
This pull request introduces two new settings to allow users to enhance their video quality.

By default, Chrome utilizes VP8 for WebRTC video encoding and imposes a 3Mbps limit on video bitrate. These limits might be too conservative, especially in the case of 1-1. Users may choose to use a more recent video encoder (if supported) / higher bitrate (if network allows) for much better video quality.