### PR TITLE
Add video codec and max bitrate settings

### DIFF
--- a/frontend/html/client.html
+++ b/frontend/html/client.html
@@ -107,6 +107,22 @@ Wait user to join.
             <label for="audioSource">🎙️ Microphone</label>
             <select id="audioSource"></select>
             <hr />
+            <label>Video codec</label>
+            <select id="videoSenderCodecSelect">
+                <option value="default">Default</option>
+                <option value="AV1/VP9">AV1/VP9</option>
+                <option value="VP9/VP8">VP9/VP8</option>
+            </select>
+            <label>Video max bitrate (Mbps)</label>
+            <select id="videoSenderMaxBitrateSelect">
+                <option value="default">Default</option>
+                <option value="16">16</option>
+                <option value="8">8</option>
+                <option value="4">4</option>
+                <option value="2">2</option>
+                <option value="1">1</option>
+            </select>
+            <hr />
             <table id="settingsTable">
                 <tr id="maxVideoQualityDiv">
                     <td><span>✨ Best quality</span></td>

--- a/frontend/html/client.html
+++ b/frontend/html/client.html
@@ -110,17 +110,19 @@ Wait user to join.
             <label>Video codec</label>
             <select id="videoSenderCodecSelect">
                 <option value="default">Default</option>
-                <option value="AV1/VP9">AV1/VP9</option>
-                <option value="VP9/VP8">VP9/VP8</option>
+                <option value="video/VP8">video/VP8</option>
+                <option value="video/VP9">video/VP9</option>
+                <option value="video/AVI">video/AV1</option>
+                <option value="video/H264">video/H264</option>
             </select>
-            <label>Video max bitrate (Mbps)</label>
+            <label>Video max bitrate</label>
             <select id="videoSenderMaxBitrateSelect">
                 <option value="default">Default</option>
-                <option value="16">16</option>
-                <option value="8">8</option>
-                <option value="4">4</option>
-                <option value="2">2</option>
-                <option value="1">1</option>
+                <option value="16">16 Mbps</option>
+                <option value="8">8 Mbps</option>
+                <option value="4">4 Mbps</option>
+                <option value="2">2 Mbps</option>
+                <option value="1">1 Mbps</option>
             </select>
             <hr />
             <table id="settingsTable">

--- a/frontend/html/client.html
+++ b/frontend/html/client.html
@@ -110,10 +110,8 @@ Wait user to join.
             <label>Video codec</label>
             <select id="videoSenderCodecSelect">
                 <option value="default">Default</option>
-                <option value="video/VP8">video/VP8</option>
-                <option value="video/VP9">video/VP9</option>
-                <option value="video/AVI">video/AV1</option>
-                <option value="video/H264">video/H264</option>
+                <option value="AV1/VP9">AV1/VP9</option>
+                <option value="VP9/VP8">VP9/VP8</option>
             </select>
             <label>Video max bitrate</label>
             <select id="videoSenderMaxBitrateSelect">

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -284,17 +284,14 @@ function resetMaxBitRate() {
     popupMessage('warning', 'Video max bitrate', 'One of the callers does not support the selected Max bitrate.', 'top', 6000);
 }
 
-async function getVideoState(peerConnection) {
+function getVideoState(peerConnection) {
     const videoTransceiver = peerConnection
         .getTransceivers()
         .find((s) => (s.sender.track ? s.sender.track.kind === 'video' : false));
-    if (!videoTransceiver) return [false, false];
+    if (!videoTransceiver) return [True, True];
 
-    const sendStat = await videoTransceiver.sender.getStats();
-    const sendState = Array.from(sendStat.entries()).some(obj => obj[1]["type"] == 'codec');
-
-    const recvStat = await videoTransceiver.receiver.getStats();
-    const recvState = Array.from(recvStat.entries()).some(obj => obj[1]["type"] == 'codec');
+    const sendState = videoTransceiver.sender.track.muted;
+    const recvState = videoTransceiver.receiver.track.muted;
 
     return [sendState, recvState];
 }
@@ -330,14 +327,14 @@ async function refreshCodec() {
     try {
         for (const peerId in peerConnections) {
             const peerConnection = peerConnections[peerId];
-            const state1 = await getVideoState(peerConnection);
+            const state1 = getVideoState(peerConnection);
 
             handleRtcOffer(peerId);
             await peerConnection.restartIce();
 
             // Wait and check check video stats
-            await new Promise(r => setTimeout(r, 1000));
-            const state2 = await getVideoState(peerConnection);
+            await new Promise(r => setTimeout(r, 2000));
+            const state2 = getVideoState(peerConnection);
             if (!(state1[0]==state2[0] && state1[1]==state2[1])) throw new Error("Video stopped after changing codec");
         }
     } catch (error) {

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -290,6 +290,7 @@ async function refreshCodec() {
         if (!thereIsPeerConnections()) return;
         for (let peerId in peerConnections) {
             let peerConnection = peerConnections[peerId];
+            handleRtcOffer(peerId);
             peerConnection.restartIce();
         }
     } catch (error) {

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -291,10 +291,10 @@ async function getVideoState(peerConnection) {
     if (!videoTransceiver) return [false, false];
 
     const sendStat = await videoTransceiver.sender.getStats();
-    const sendState = sendStat.entries().some(obj => obj[1]["type"] == 'codec');
+    const sendState = Array.from(sendStat.entries()).some(obj => obj[1]["type"] == 'codec');
 
     const recvStat = await videoTransceiver.receiver.getStats();
-    const recvState = recvStat.entries().some(obj => obj[1]["type"] == 'codec');
+    const recvState = Array.from(recvStat.entries()).some(obj => obj[1]["type"] == 'codec');
 
     return [sendState, recvState];
 }

--- a/frontend/js/client.js
+++ b/frontend/js/client.js
@@ -357,9 +357,14 @@ async function refreshBitrate() {
             if (videoTransceiver) {
                 const videoSender = videoTransceiver.sender;
                 const videoParameters = await videoSender.getParameters();
-                const newMaxBitrate = parseInt(config.videoSenderMaxBitrate) * 1000000;
-                if (config.videoSenderMaxBitrate != 'default') videoParameters.encodings[0].maxBitrate = newMaxBitrate;
-                else if (videoParameters.encodings[0].hasOwnProperty("maxBitrate")) delete videoParameters.encodings[0].maxBitrate;
+                if (config.videoSenderMaxBitrate === 'default'){
+                    if (videoParameters.encodings[0].hasOwnProperty("maxBitrate")) {
+                        delete videoParameters.encodings[0].maxBitrate;
+                    }
+                } else {
+                    const newMaxBitrate = parseInt(config.videoSenderMaxBitrate) * 1000000;
+                    videoParameters.encodings[0].maxBitrate = newMaxBitrate;
+                }
                 await videoSender.setParameters(videoParameters);
                 console.log(`Max bitrate changed for ${peerId} to ${config.videoSenderMaxBitrate} Mbps`, {
                     encodings: videoParameters.encodings[0],


### PR DESCRIPTION
This pull request introduces two new settings to allow users to enhance their video quality.

By default, Chrome utilizes VP8 for WebRTC video encoding and imposes a 3Mbps limit on video bitrate. These limits might be too conservative, especially in the case of 1-1. Users may choose to use a more recent video encoder (if supported) / higher bitrate (if network allows) for much better video quality.